### PR TITLE
Try to create the cache directory before throwing an exception

### DIFF
--- a/classes/Kohana/Twig.php
+++ b/classes/Kohana/Twig.php
@@ -35,7 +35,7 @@ class Kohana_Twig extends View {
 		$path = Kohana::$config->load('twig.environment.cache');
 		if ( ! is_writable($path) AND ! self::_init_cache($path))
 		{
-			throw new Kohana_Exception('Directory :dir must be writable', array(
+			throw new Kohana_Exception('Directory :dir must exist and be writable', array(
 				':dir' => Debug::path($path),
 			));
 		}


### PR DESCRIPTION
I think it is less restrictive if the module try to create the cache directory before throwing an exception.
