### PR TITLE
use __DIR__ instead of __FILE__ for simplicity

### DIFF
--- a/init.php
+++ b/init.php
@@ -1,4 +1,4 @@
 <?php defined('SYSPATH') or die('No direct script access.');
 
-define('TWIGPATH', rtrim(dirname(__FILE__), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR);
+define('TWIGPATH', __DIR__ . DIRECTORY_SEPARATOR);
 Twig::init();


### PR DESCRIPTION
practically, `__DIR__` will not contain the trailing slash
so there is no need for `rtrim`.
