### PR TITLE
use Twig_Exception instead of Twig_Error_Loader

### DIFF
--- a/classes/Twig/Loader/CFS.php
+++ b/classes/Twig/Loader/CFS.php
@@ -30,7 +30,7 @@ class Twig_Loader_CFS implements Twig_LoaderInterface {
 	{
 		if (($path = Kohana::find_file($this->_config['path'], $name, $this->_config['extension'])) === FALSE)
 		{
-			throw new Twig_Error_Loader('The requested twig :name could not be found', array(
+			throw new Twig_Exception('The requested twig :name could not be found', array(
 				':name' => $name,
 			));
 		}


### PR DESCRIPTION
`Twig_Exception` will allow the interpolation of the 
`:name` variable, the Kohana way
