### PR TITLE
solve race condition when deploying a new server

### DIFF
--- a/classes/Kohana/Twig.php
+++ b/classes/Kohana/Twig.php
@@ -18,10 +18,10 @@ class Kohana_Twig extends View {
 	 */
 	protected static function _init_cache($path)
 	{
-		if (mkdir($path, 0755, TRUE) AND chmod($path, 0755))
+		if (@mkdir($path, 0755, TRUE) AND chmod($path, 0755))
 			return TRUE;
 
-		return FALSE;
+		return is_dir($path);
 	}
 
 	/**


### PR DESCRIPTION
When starting a new server - for example when deploying to heroku or elastic beanstalk, multiple requests may try to `_init_cache()` at the same time, where one would succeed and the other would get `directory already exists`. Its a race condition, so I don't think doing `file_exists()` before `mkdir()` makes sense (though it is often recommended on the web).

Instead I believe its better to just try to recover from `mkdir()` failing while the requirement still being fulfilled.